### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ continuing:
 $ cpanm Dist::Zilla
 ```
 
-To install the required prequisite packages, run the following set of
+To install the required prerequisite packages, run the following set of
 commands:
 
 ```

--- a/README.mkdn
+++ b/README.mkdn
@@ -86,7 +86,7 @@ continuing:
 $ cpanm Dist::Zilla
 ```
 
-To install the required prequisite packages, run the following set of
+To install the required prerequisite packages, run the following set of
 commands:
 
 ```

--- a/lib/Dist/Zilla/Plugin/ReadmeAddDevInfo.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAddDevInfo.pm
@@ -168,7 +168,7 @@ continuing:
 \$ cpanm Dist::Zilla
 ```
 
-To install the required prequisite packages, run the following set of
+To install the required prerequisite packages, run the following set of
 commands:
 
 ```


### PR DESCRIPTION
Hi Renee,

while playing with `MySQL::Workbench::Merge` I noticed a typo in the README and CONTRIBUTING files and tracked it back to this repo.  Anyway, thought you'd like to have this fixed in the base package :-)