### PR TITLE
Purge trailing whitespace

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReadmeAddDevInfo.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAddDevInfo.pm
@@ -62,11 +62,11 @@ has contribution_file => (
             # for the other phases we look on disk
             my $root = path($self->zilla->root);
 
-            return Dist::Zilla::File::OnDisk->new( 
+            return Dist::Zilla::File::OnDisk->new(
                 name    => "$_",
                 content => $_->slurp_raw,
                 encoding => 'bytes',
-            ) for grep { -f $_ } map { $root->child($_) } @candidates 
+            ) for grep { -f $_ } map { $root->child($_) } @candidates
         }
 
         if ( $self->add_contribution_file ) {
@@ -100,11 +100,11 @@ has readme_file => (
             # for the other phases we look on disk
             my $root = path($self->zilla->root);
 
-            return Dist::Zilla::File::OnDisk->new( 
+            return Dist::Zilla::File::OnDisk->new(
                 name    => "$_",
                 content => $_->slurp_raw,
                 encoding => 'bytes',
-            ) for grep { -f $_ } map { $root->child($_) } @candidates 
+            ) for grep { -f $_ } map { $root->child($_) } @candidates
         }
 
         $self->log_fatal('README file not found') if !$self->{contributing_file_only};


### PR DESCRIPTION
Some projects consider this a must, and will disallow commits to be
submitted which contain trailing whitespace (the Linux kernel is an example
project where trailing whitespace isn't permitted).  Other projects see
whitespace cleanup as simply nit-picking.  Either way I thought this
could be helpful.  Feel free to close this PR unmerged if you don't want this change.